### PR TITLE
feat: add humidity display, state persistence after reboot, improve IR reception

### DIFF
--- a/esphome/Panasonic-Ac.yaml
+++ b/esphome/Panasonic-Ac.yaml
@@ -1,0 +1,151 @@
+esphome:
+  name: "panasonic-ac"
+  friendly_name: "Panasonic AC"
+  min_version: 2025.9.0
+  name_add_mac_suffix: false
+  project: 
+    name: "AnhThao.Panasonic_Remote"
+    version: "D1mini_V4.0"
+
+external_components:
+  - source: components # https://github.com/hoangminh1109/PanaAC_ESPHome/tree/main
+
+esp8266:
+  board: d1_mini # LOLIN D1Mini V4.0
+
+# Enable logging
+logger:
+  level: INFO
+  
+# Enable Home Assistant API
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  min_auth_mode: WPA2
+  fast_connect: true
+  #use_address: 192.168.1.72 # Chỉ định flash/ota cho thiết bị có ip đó
+  
+  # Fallback AP used when Wi-Fi connection fails
+  ap:
+    ssid: "Panasonic-AC"
+    password: !secret ap_password
+
+# Enables captive portal web interface if using fallback AP
+captive_portal:
+
+# --- SCRIPT NHÁY ĐÈN ---
+script:
+  - id: flash_led
+    mode: restart
+    then:
+      - repeat:
+          count: 2 # Số lần led nháy
+          then:
+            - output.turn_on: status_led_output
+            - delay: 50ms
+            - output.turn_off: status_led_output
+            - delay: 50ms # Khoảng nghỉ giữa các lần nháy
+
+# --- LED OUTPUT ---
+output:
+  - platform: gpio
+    pin: 
+      number: GPIO2
+      inverted: true
+    id: status_led_output
+
+# --- INFRARED RECEIVER ---
+remote_receiver:
+  pin:
+      number: GPIO4
+      inverted: true
+      mode: OUTPUT_OPEN_DRAIN
+      allow_other_uses: true
+  tolerance: 55%
+  id: ir_receiver
+  buffer_size: 2kb
+  idle: 15ms # required (>10ms frame gap để nhận cả 2 frame liền)
+
+# --- INFRARED TRANSMITTER ---
+remote_transmitter:
+  carrier_duty_percent: 50%
+  pin:
+      number: GPIO4
+      inverted: true
+      mode: OUTPUT_OPEN_DRAIN
+      allow_other_uses: true
+  # Nháy đèn khi phát từ Hass
+  on_transmit:
+    then:
+      - script.execute: flash_led
+
+# --- CLIMATE ---
+climate:
+  - platform: panaac
+    name: ""
+    receiver_id: ir_receiver
+    supports_fan_only: false
+    supports_heat: false
+    supports_quiet: true
+    swing_horizontal: false
+    fan_5level: true
+    ir_control: false
+    
+    # Hiển thị cảm biến phòng hiện tại
+    sensor: nhiet_do
+    humidity_sensor: do_am
+    # Nháy đèn khi trạng thái thay đổi (Đồng bộ 2 chiều)
+    on_state:
+      then:
+        - script.execute: flash_led
+        
+# --- Sensor Temperature & Humidity ---
+sensor:
+  - platform: homeassistant
+    name: "Nhiệt độ"
+    id: nhiet_do
+    entity_id: sensor.atc4_temperature # Thay Sensor nhiệt độ phòng hiện tại
+    internal: true
+
+  - platform: homeassistant
+    name: "Độ ẩm"
+    id: do_am
+    entity_id: sensor.atc4_humidity # Thay Sensor độ ẩm phòng hiện tại
+    internal: true
+
+  - platform: uptime
+    name: "Uptime"
+    update_interval: 60s
+  - platform: wifi_signal
+    name: "WiFi RSSI"
+    update_interval: 60s
+    disabled_by_default: true
+    
+# --- Restart ESP12E ---
+switch:
+  - platform: restart
+    name: "ESP Reboot"
+
+# --- IP Address ---
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP"
+      entity_category: "diagnostic"
+      disabled_by_default: False
+      icon: mdi:ip-network
+
+# --- Status Connected ---
+binary_sensor:
+  - platform: status
+    name: "Status"
+    id: ink_ha_connected

--- a/esphome/components/panaac/panaac.cpp
+++ b/esphome/components/panaac/panaac.cpp
@@ -25,16 +25,29 @@ namespace esphome
         {
             ClimateIR::setup();
 
-            // state
-            ac_state.mode = climate::CLIMATE_MODE_OFF;
-            ac_state.temp = 26.0;
-            ac_state.fan_mode = climate::CLIMATE_FAN_AUTO;
-            ac_state.fan_level = PANAAC_FAN_AUTO;
-            ac_state.swing_mode = climate::CLIMATE_SWING_VERTICAL;
-            ac_state.swing_v_pos = PANAAC_SWINGV_AUTO;
-            ac_state.swing_h_pos = PANAAC_SWINGH_AUTO;
-            ac_state.last_swing_v_pos = PANAAC_SWINGV_MIDDLE;
-            ac_state.last_swing_h_pos = PANAAC_SWINGH_MIDDLE;
+            // Tạo preference object để lưu/đọc trạng thái từ flash
+            this->pref_ = global_preferences->make_preference<ClimateState>(this->get_object_id_hash());
+
+            // Thử khôi phục trạng thái từ flash
+            if (!this->pref_.load(&this->ac_state))
+            {
+                // Lần đầu tiên hoặc flash chưa có dữ liệu: dùng giá trị mặc định
+                ESP_LOGI(TAG, "No saved state found, using defaults");
+                ac_state.mode = climate::CLIMATE_MODE_OFF;
+                ac_state.temp = 26.0;
+                ac_state.fan_mode = climate::CLIMATE_FAN_AUTO;
+                ac_state.fan_level = PANAAC_FAN_AUTO;
+                ac_state.swing_mode = climate::CLIMATE_SWING_VERTICAL;
+                ac_state.swing_v_pos = PANAAC_SWINGV_AUTO;
+                ac_state.swing_h_pos = PANAAC_SWINGH_AUTO;
+                ac_state.last_swing_v_pos = PANAAC_SWINGV_MIDDLE;
+                ac_state.last_swing_h_pos = PANAAC_SWINGH_MIDDLE;
+            }
+            else
+            {
+                ESP_LOGI(TAG, "Restored saved state: mode=%d, temp=%.1f, fan=%d, swing=%d",
+                         ac_state.mode, ac_state.temp, ac_state.fan_mode, ac_state.swing_mode);
+            }
 
             // fan level options
             FixedVector<const char *> fanlevel_options;
@@ -72,20 +85,20 @@ namespace esphome
                 this->swingh_->traits.set_options({STR_SWINGH_AUTO, STR_SWINGH_LEFTMAX, STR_SWINGH_LEFT, STR_SWINGH_MIDDLE, STR_SWINGH_RIGHT, STR_SWINGH_RIGHTMAX});
             }
 
-            // initial state
-            this->mode = climate::CLIMATE_MODE_OFF;
-            this->target_temperature = 26.0;
-            this->fan_mode = climate::CLIMATE_FAN_AUTO;
+            // Khôi phục trạng thái từ ac_state (KHÔNG phát IR)
+            this->mode = ac_state.mode;
+            this->target_temperature = ac_state.temp;
+            this->fan_mode = ac_state.fan_mode;
+            this->swing_mode = ac_state.swing_mode;
+            this->publish_state();
+
+            // Khôi phục trạng thái cho các select (Fan Level, Swing V, Swing H)
+            this->fanlevel_->set_fanlevel(ac_state.fan_level);
+            this->swingv_->set_swingvpos(ac_state.swing_v_pos);
             if (this->swing_horizontal_)
             {
-                this->swing_mode = climate::CLIMATE_SWING_BOTH;
+                this->swingh_->set_swinghpos(ac_state.swing_h_pos);
             }
-            else
-            {
-                this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-            }
-
-            transmit_state();
 
         }
 
@@ -99,6 +112,10 @@ namespace esphome
             else
             {
                 traits.clear_feature_flags(climate::ClimateFeature::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+            }
+            if (this->humidity_sensor_ != nullptr)
+            {
+                traits.add_feature_flags(climate::ClimateFeature::CLIMATE_SUPPORTS_CURRENT_HUMIDITY);
             }
             traits.clear_feature_flags(climate::ClimateFeature::CLIMATE_SUPPORTS_ACTION);
             traits.set_visual_min_temperature(PANAAC_TEMP_MIN);
@@ -418,6 +435,8 @@ namespace esphome
             {
                 this->swingh_->set_swinghpos(ac_state.swing_h_pos);
             }
+
+            this->save_state();
             
             return true;
         }
@@ -716,6 +735,8 @@ namespace esphome
             {
                 this->swingh_->set_swinghpos(ac_state.swing_h_pos);
             }
+
+            this->save_state();
         }
 
         void PanaACClimate::update_state()
@@ -737,6 +758,14 @@ namespace esphome
 
             this->publish_state();
 
+            this->save_state();
+
+        }
+
+        void PanaACClimate::save_state()
+        {
+            this->pref_.save(&this->ac_state);
+            ESP_LOGD(TAG, "State saved to flash");
         }
 
     } // namespace panaac

--- a/esphome/components/panaac/panaac.h
+++ b/esphome/components/panaac/panaac.h
@@ -19,6 +19,7 @@
 #include "definitions.h"
 #include "extra.h"
 #include <cinttypes>
+#include "esphome/core/preferences.h"
 
 namespace esphome
 {
@@ -54,6 +55,7 @@ namespace esphome
 
             void update_state();
             void transmit_data();
+            void save_state();
 
             ClimateState ac_state;
             bool swing_horizontal_;
@@ -76,6 +78,8 @@ namespace esphome
             PanaACFanLevel *fanlevel_{nullptr};
             PanaACSwingV *swingv_{nullptr};
             PanaACSwingH *swingh_{nullptr};
+
+            ESPPreferenceObject pref_;
         };
 
 


### PR DESCRIPTION
## Changes

### 1. Humidity sensor display (panaac.cpp)
- Added CLIMATE_SUPPORTS_CURRENT_HUMIDITY in traits() so humidity_sensor actually shows on HA climate card

### 2. State persistence after reboot (panaac.h + panaac.cpp)
- Uses ESPHome Preferences API to save ClimateState to flash
- On reboot: restores mode, temperature, fan level, swing position WITHOUT transmitting IR
- Fan Level and Swing Vertical selects no longer show "Unknown" after reboot

### 3. Improve IR reception (Panasonic-Ac.yaml)
- Changed idle from 5ms to 15ms (> 10ms Panasonic frame gap)
- Both frames captured as single transmission, more reliable on ESP8266