### PR TITLE
fix: add fan-only helper switch for HomeKit

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,40 @@
+## Summary
+
+Fixes #16.
+
+Adds an optional `fan_only_switch:` helper entity for users who bridge this climate through HomeKit. HomeKit does not expose a native `FAN_ONLY` climate mode, so the switch provides a bridge-friendly control that toggles the AC into and out of `FAN_ONLY` while keeping the climate entity state synchronized.
+
+## Scope
+
+- `esphome/components/panaac/climate.py`
+  - adds `fan_only_switch:` and `fan_only_switch_id:` schema support
+  - registers a companion switch only when both `supports_fan_only: true` and `fan_only_switch: true` are set
+- `esphome/components/panaac/definitions.h`, `extra.h`, `extra.cpp`
+  - introduces a `PanaACFanOnlySwitch` helper entity
+- `esphome/components/panaac/panaac.h`, `panaac.cpp`
+  - tracks the last non-`FAN_ONLY` operating mode
+  - keeps the helper switch synchronized on local updates and received IR state changes
+- `README.md`
+  - documents the new optional config and its HomeKit use case
+
+## Design
+
+- The fix stays inside this component instead of depending on Home Assistant or HomeKit changes.
+- The helper is opt-in to avoid adding extra entities for users who do not need HomeKit workarounds.
+- Turning the switch on sets `FAN_ONLY` mode.
+- Turning the switch off restores the last non-`FAN_ONLY` operating mode when possible, which keeps the UX closer to a mode toggle than a hard power-off.
+- The switch publishes its state from both outbound updates and IR receive events so Home Assistant and HomeKit stay aligned.
+
+## Changes
+
+- Added `switch` auto-loading and config registration for the helper entity.
+- Added runtime synchronization between the climate state and the switch state.
+- Added restore logic for leaving `FAN_ONLY` mode cleanly.
+- Updated the README examples to show `fan_only_switch: true`.
+
+## Verification
+
+- Ran `python -m py_compile esphome/components/panaac/climate.py`
+- Ran `git diff --check`
+
+PR by Codex

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You have 2 options to install ESPHome module to you AC.
                 supports_heat: true
                 supports_quiet: true
                 fan_5level: true
+                fan_only_switch: true
                 swing_horizontal: false
                 temp_step: 0.5
                 ir_control: false
@@ -125,10 +126,13 @@ You have 2 options to install ESPHome module to you AC.
                 supports_heat: true
                 supports_quiet: True
                 fan_5level: True
+                fan_only_switch: True
                 swing_horizontal: True
                 temp_step: 0.5
                 ir_control: True
         ```
+
+    - `fan_only_switch` is optional and creates a companion switch entity for users who expose this climate through HomeKit. HomeKit does not provide a native FAN_ONLY climate mode, but it can surface a switch that toggles the AC into and out of FAN_ONLY.
 
     - **NOTE:**
         - Panasonic AC IR protocol includes 2 IR frames

--- a/esphome/components/panaac/climate.py
+++ b/esphome/components/panaac/climate.py
@@ -14,16 +14,17 @@
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate_ir, select
+from esphome.components import climate_ir, select, switch
 from esphome.const import CONF_ID, CONF_NAME, CONF_DISABLED_BY_DEFAULT
 
-AUTO_LOAD = ['climate_ir','select']
+AUTO_LOAD = ['climate_ir', 'select', 'switch']
 
 panaac_ns = cg.esphome_ns.namespace('panaac')
 PanaACClimate = panaac_ns.class_('PanaACClimate', climate_ir.ClimateIR)
 PanaACFanLevel = panaac_ns.class_('PanaACFanLevel', select.Select, cg.Component)
 PanaACSwingV = panaac_ns.class_('PanaACSwingV', select.Select, cg.Component)
 PanaACSwingH = panaac_ns.class_('PanaACSwingH', select.Select, cg.Component)
+PanaACFanOnlySwitch = panaac_ns.class_('PanaACFanOnlySwitch', switch.Switch, cg.Component)
 
 CONF_SUPPORT_FAN_ONLY = "supports_fan_only"
 CONF_SWING_HORIZONTAL = "swing_horizontal"
@@ -31,22 +32,26 @@ CONF_TEMP_STEP = "temp_step"
 CONF_SUPPORT_QUIET = "supports_quiet"
 CONF_FAN_5LEVEL = "fan_5level"
 CONF_IR_CONTROL = "ir_control"
+CONF_FAN_ONLY_SWITCH = "fan_only_switch"
 
 CONF_SWINGV_ID = "swingv_id"
 CONF_SWINGH_ID = "swingh_id"
 CONF_FANLEVEL_ID = "fanlevel_id"
+CONF_FAN_ONLY_SWITCH_ID = "fan_only_switch_id"
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(PanaACClimate).extend({
     cv.GenerateID(): cv.declare_id(PanaACClimate),
     cv.GenerateID(CONF_SWINGV_ID): cv.declare_id(PanaACSwingV),
     cv.GenerateID(CONF_SWINGH_ID): cv.declare_id(PanaACSwingH),
     cv.GenerateID(CONF_FANLEVEL_ID): cv.declare_id(PanaACFanLevel),
+    cv.GenerateID(CONF_FAN_ONLY_SWITCH_ID): cv.declare_id(PanaACFanOnlySwitch),
     cv.Optional(CONF_SWING_HORIZONTAL, default=False): cv.boolean,
     cv.Optional(CONF_TEMP_STEP, default=1.0): cv.float_,
     cv.Optional(CONF_SUPPORT_QUIET, default=False): cv.boolean,
     cv.Optional(CONF_SUPPORT_FAN_ONLY, default=False): cv.boolean,
     cv.Optional(CONF_FAN_5LEVEL, default=False): cv.boolean,
     cv.Optional(CONF_IR_CONTROL, default=False): cv.boolean,
+    cv.Optional(CONF_FAN_ONLY_SWITCH, default=False): cv.boolean,
 })
 
 async def to_code(config):
@@ -90,3 +95,15 @@ async def to_code(config):
         await cg.register_component(swingh, swingh_default_config)
         cg.add(swingh.set_parent_climate(var))
         cg.add(var.set_swingh(swingh))
+
+    if config[CONF_SUPPORT_FAN_ONLY] and config[CONF_FAN_ONLY_SWITCH]:
+        fan_only_switch_default_config = {
+            CONF_ID: config[CONF_FAN_ONLY_SWITCH_ID],
+            CONF_NAME: "- Fan Only",
+            CONF_DISABLED_BY_DEFAULT: False,
+        }
+        fan_only_switch = cg.new_Pvariable(config[CONF_FAN_ONLY_SWITCH_ID])
+        await switch.register_switch(fan_only_switch, fan_only_switch_default_config)
+        await cg.register_component(fan_only_switch, fan_only_switch_default_config)
+        cg.add(fan_only_switch.set_parent_climate(var))
+        cg.add(var.set_fan_only_switch(fan_only_switch))

--- a/esphome/components/panaac/definitions.h
+++ b/esphome/components/panaac/definitions.h
@@ -19,6 +19,7 @@
 #include "esphome/components/climate_ir/climate_ir.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/remote_base/remote_base.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/core/log.h"
 #include <cstdlib>
 #include <cinttypes>
@@ -128,6 +129,7 @@ namespace esphome
         static const char *STR_SWINGH_RIGHTMAX = "Right Max";
 
         class PanaACClimate;
+        class PanaACFanOnlySwitch;
 
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/extra.cpp
+++ b/esphome/components/panaac/extra.cpp
@@ -360,5 +360,35 @@ namespace esphome
         {
         }
 
+        void PanaACFanOnlySwitch::dump_config()
+        {
+            ESP_LOGCONFIG(TAG, "PanaACFanOnlySwitch:");
+            LOG_SWITCH("  Fan Only: ", "switch", this);
+        }
+
+        void PanaACFanOnlySwitch::write_state(bool state)
+        {
+            if (state)
+            {
+                this->climate_->ac_state.mode = climate::CLIMATE_MODE_FAN_ONLY;
+            }
+            else if (this->climate_->ac_state.mode == climate::CLIMATE_MODE_FAN_ONLY)
+            {
+                this->climate_->ac_state.mode = this->climate_->get_restore_mode_from_fan_only();
+            }
+
+            this->climate_->update_state();
+            this->publish_state(this->climate_->ac_state.mode == climate::CLIMATE_MODE_FAN_ONLY);
+        }
+
+        void PanaACFanOnlySwitch::sync_state()
+        {
+            this->publish_state(this->climate_->ac_state.mode == climate::CLIMATE_MODE_FAN_ONLY);
+        }
+
+        void PanaACFanOnlySwitch::setup()
+        {
+        }
+
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/extra.h
+++ b/esphome/components/panaac/extra.h
@@ -62,5 +62,18 @@ namespace esphome
             PanaACClimate *climate_{nullptr};
         };
 
+        class PanaACFanOnlySwitch : public switch_::Switch, public Component
+        {
+        public:
+            void setup() override;
+            void dump_config() override;
+            void write_state(bool state) override;
+            void set_parent_climate(PanaACClimate *climate) { this->climate_ = climate; }
+            void sync_state();
+
+        protected:
+            PanaACClimate *climate_{nullptr};
+        };
+
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/panaac.cpp
+++ b/esphome/components/panaac/panaac.cpp
@@ -85,8 +85,42 @@ namespace esphome
                 this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
             }
 
+            this->remember_last_non_fan_only_mode_();
+            this->sync_helper_entities_();
             transmit_state();
 
+        }
+
+        climate::ClimateMode PanaACClimate::get_restore_mode_from_fan_only() const
+        {
+            if (this->last_non_fan_only_mode_ == climate::CLIMATE_MODE_HEAT && !this->supports_heat_)
+            {
+                return climate::CLIMATE_MODE_AUTO;
+            }
+
+            return this->last_non_fan_only_mode_;
+        }
+
+        void PanaACClimate::remember_last_non_fan_only_mode_()
+        {
+            if (ac_state.mode != climate::CLIMATE_MODE_FAN_ONLY && ac_state.mode != climate::CLIMATE_MODE_OFF)
+            {
+                this->last_non_fan_only_mode_ = ac_state.mode;
+            }
+        }
+
+        void PanaACClimate::sync_helper_entities_()
+        {
+            this->fanlevel_->set_fanlevel(ac_state.fan_level);
+            this->swingv_->set_swingvpos(ac_state.swing_v_pos);
+            if (this->swing_horizontal_)
+            {
+                this->swingh_->set_swinghpos(ac_state.swing_h_pos);
+            }
+            if (this->fan_only_switch_ != nullptr)
+            {
+                this->fan_only_switch_->sync_state();
+            }
         }
 
         climate::ClimateTraits PanaACClimate::traits() {
@@ -410,14 +444,9 @@ namespace esphome
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->remember_last_non_fan_only_mode_();
             this->publish_state();
-
-            this->fanlevel_->set_fanlevel(ac_state.fan_level);
-            this->swingv_->set_swingvpos(ac_state.swing_v_pos);
-            if (this->swing_horizontal_)
-            {
-                this->swingh_->set_swinghpos(ac_state.swing_h_pos);
-            }
+            this->sync_helper_entities_();
             
             return true;
         }
@@ -708,14 +737,9 @@ namespace esphome
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->remember_last_non_fan_only_mode_();
             this->publish_state();
-
-            this->fanlevel_->set_fanlevel(ac_state.fan_level);
-            this->swingv_->set_swingvpos(ac_state.swing_v_pos);
-            if (this->swing_horizontal_)
-            {
-                this->swingh_->set_swinghpos(ac_state.swing_h_pos);
-            }
+            this->sync_helper_entities_();
         }
 
         void PanaACClimate::update_state()
@@ -725,16 +749,10 @@ namespace esphome
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->remember_last_non_fan_only_mode_();
             transmit_data();
 
-            // update state of additional selects
-            this->fanlevel_->set_fanlevel(ac_state.fan_level);
-            this->swingv_->set_swingvpos(ac_state.swing_v_pos);
-            if (this->swing_horizontal_)
-            {
-                this->swingh_->set_swinghpos(ac_state.swing_h_pos);
-            }
-
+            this->sync_helper_entities_();
             this->publish_state();
 
         }

--- a/esphome/components/panaac/panaac.h
+++ b/esphome/components/panaac/panaac.h
@@ -51,18 +51,22 @@ namespace esphome
             void set_fanlevel(PanaACFanLevel *fanlevel) { this->fanlevel_ = fanlevel; }
             void set_swingv(PanaACSwingV *swingv) { this->swingv_ = swingv; }
             void set_swingh(PanaACSwingH *swingh) { this->swingh_ = swingh; }
+            void set_fan_only_switch(PanaACFanOnlySwitch *fan_only_switch) { this->fan_only_switch_ = fan_only_switch; }
 
             void update_state();
             void transmit_data();
 
             ClimateState ac_state;
             bool swing_horizontal_;
+            climate::ClimateMode get_restore_mode_from_fan_only() const;
 
         protected:
             void setup() override;
             void transmit_state() override;
             bool on_receive(remote_base::RemoteReceiveData data) override;
             climate::ClimateTraits traits() override;
+            void sync_helper_entities_();
+            void remember_last_non_fan_only_mode_();
 
             bool decode_data(remote_base::RemoteReceiveData data, std::vector<uint8_t>& state_bytes);
             bool decode_state(std::vector<uint8_t> state_bytes, ClimateState& state);
@@ -72,10 +76,12 @@ namespace esphome
             bool fan_5level_;
             bool ir_control_;
             bool supports_fan_only_;
+            climate::ClimateMode last_non_fan_only_mode_{climate::CLIMATE_MODE_AUTO};
 
             PanaACFanLevel *fanlevel_{nullptr};
             PanaACSwingV *swingv_{nullptr};
             PanaACSwingH *swingh_{nullptr};
+            PanaACFanOnlySwitch *fan_only_switch_{nullptr};
         };
 
 


### PR DESCRIPTION
## Summary

Fixes #16.

Adds an optional `fan_only_switch:` helper entity for users who bridge this climate through HomeKit. HomeKit does not expose a native `FAN_ONLY` climate mode, so the switch provides a bridge-friendly control that toggles the AC into and out of `FAN_ONLY` while keeping the climate entity state synchronized.

## Scope

- `esphome/components/panaac/climate.py`
  - adds `fan_only_switch:` and `fan_only_switch_id:` schema support
  - registers a companion switch only when both `supports_fan_only: true` and `fan_only_switch: true` are set
- `esphome/components/panaac/definitions.h`, `extra.h`, `extra.cpp`
  - introduces a `PanaACFanOnlySwitch` helper entity
- `esphome/components/panaac/panaac.h`, `panaac.cpp`
  - tracks the last non-`FAN_ONLY` operating mode
  - keeps the helper switch synchronized on local updates and received IR state changes
- `README.md`
  - documents the new optional config and its HomeKit use case

## Design

- The fix stays inside this component instead of depending on Home Assistant or HomeKit changes.
- The helper is opt-in to avoid adding extra entities for users who do not need HomeKit workarounds.
- Turning the switch on sets `FAN_ONLY` mode.
- Turning the switch off restores the last non-`FAN_ONLY` operating mode when possible, which keeps the UX closer to a mode toggle than a hard power-off.
- The switch publishes its state from both outbound updates and IR receive events so Home Assistant and HomeKit stay aligned.

## Changes

- Added `switch` auto-loading and config registration for the helper entity.
- Added runtime synchronization between the climate state and the switch state.
- Added restore logic for leaving `FAN_ONLY` mode cleanly.
- Updated the README examples to show `fan_only_switch: true`.

## Verification

- Ran `python -m py_compile esphome/components/panaac/climate.py`
- Ran `git diff --check`

PR by Codex
