### PR TITLE
fix: group companion selects under climate device_id

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,33 @@
+## Summary
+
+Fixes #15.
+
+Passes the climate entity's `device_id:` through to the companion `select` entities so they stay grouped with the main climate under the same ESPHome sub-device in ESPHome and Home Assistant.
+
+## Scope
+
+- `esphome/components/panaac/climate.py`
+  - imports `CONF_DEVICE_ID`
+  - adds a small helper to build companion entity configs consistently
+  - forwards `device_id:` to Fan Level, Swing Vertical, and Swing Horizontal selects when present
+- `README.md`
+  - documents the `device_id:` behavior for sub-device users
+
+## Design
+
+- The fix targets the root cause in code generation: helper entities were registered without the climate's `device_id:`.
+- Existing configurations without `device_id:` keep their current behavior.
+- The solution is intentionally narrow and does not rename entities or change unrelated Home Assistant presentation details.
+
+## Changes
+
+- Centralized companion entity config creation in `build_entity_config(...)`.
+- Copied `device_id:` only when the parent climate config includes it.
+- Added a short README note so the feature is discoverable.
+
+## Verification
+
+- Ran `python -m py_compile esphome/components/panaac/climate.py`
+- Ran `git diff --check`
+
+PR by Codex

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You have 2 options to install ESPHome module to you AC.
         climate:
             - platform: panaac
                 name: "Remote Controller"
+                device_id: hvac
                 receiver_id: ir_receiver
                 supports_fan_only: true
                 supports_heat: true
@@ -100,6 +101,8 @@ You have 2 options to install ESPHome module to you AC.
                 temp_step: 0.5
                 ir_control: false
         ```
+
+    - If you use ESPHome sub-devices, set `device_id:` on the climate entity. The companion selects created by this component inherit the same `device_id` and stay grouped with the climate in ESPHome and Home Assistant.
 
     - If you're installing the ESPHome device as a separated device and communicate with AC with real IR leds (non-invasive way), use different GPIO pins for `remote_receiver` and `remote_transmitter`. **Additionaly parameter `ir_control` needs to be True**.
 

--- a/esphome/components/panaac/climate.py
+++ b/esphome/components/panaac/climate.py
@@ -15,7 +15,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate_ir, select
-from esphome.const import CONF_ID, CONF_NAME, CONF_DISABLED_BY_DEFAULT
+from esphome.const import CONF_DEVICE_ID, CONF_DISABLED_BY_DEFAULT, CONF_ID, CONF_NAME
 
 AUTO_LOAD = ['climate_ir','select']
 
@@ -49,6 +49,17 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(PanaACClimate).extend
     cv.Optional(CONF_IR_CONTROL, default=False): cv.boolean,
 })
 
+
+def build_entity_config(config, entity_id, name):
+    entity_config = {
+        CONF_ID: entity_id,
+        CONF_NAME: name,
+        CONF_DISABLED_BY_DEFAULT: False,
+    }
+    if CONF_DEVICE_ID in config:
+        entity_config[CONF_DEVICE_ID] = config[CONF_DEVICE_ID]
+    return entity_config
+
 async def to_code(config):
     var = await climate_ir.new_climate_ir(config)
     # var = cg.new_Pvariable(config[CONF_ID])
@@ -61,9 +72,7 @@ async def to_code(config):
     cg.add(var.set_ir_control(config[CONF_IR_CONTROL]))
 
     # Fan level select
-    fanlevel_default_config = { CONF_ID: config[CONF_FANLEVEL_ID],
-                                CONF_NAME: "- Fan Level",
-                                CONF_DISABLED_BY_DEFAULT: False}
+    fanlevel_default_config = build_entity_config(config, config[CONF_FANLEVEL_ID], "- Fan Level")
     fanlevel = cg.new_Pvariable(config[CONF_FANLEVEL_ID])
     await select.register_select(fanlevel, fanlevel_default_config, options=[])
     await cg.register_component(fanlevel, fanlevel_default_config)
@@ -71,9 +80,7 @@ async def to_code(config):
     cg.add(var.set_fanlevel(fanlevel))
     
     # SwingV select
-    swingv_default_config = {   CONF_ID: config[CONF_SWINGV_ID],
-                                CONF_NAME: "- Swing Vertical",
-                                CONF_DISABLED_BY_DEFAULT: False}
+    swingv_default_config = build_entity_config(config, config[CONF_SWINGV_ID], "- Swing Vertical")
     swingv = cg.new_Pvariable(config[CONF_SWINGV_ID])
     await select.register_select(swingv, swingv_default_config, options=[])
     await cg.register_component(swingv, swingv_default_config)
@@ -82,9 +89,7 @@ async def to_code(config):
 
     # SwingH select
     if config[CONF_SWING_HORIZONTAL]:
-        swingh_default_config = {   CONF_ID: config[CONF_SWINGH_ID],
-                                    CONF_NAME: "- Swing Horizontal",
-                                    CONF_DISABLED_BY_DEFAULT: False}
+        swingh_default_config = build_entity_config(config, config[CONF_SWINGH_ID], "- Swing Horizontal")
         swingh = cg.new_Pvariable(config[CONF_SWINGH_ID])
         await select.register_select(swingh, swingh_default_config, options=[])
         await cg.register_component(swingh, swingh_default_config)


### PR DESCRIPTION
## Summary

Fixes #15.

Passes the climate entity's `device_id:` through to the companion `select` entities so they stay grouped with the main climate under the same ESPHome sub-device in ESPHome and Home Assistant.

## Scope

- `esphome/components/panaac/climate.py`
  - imports `CONF_DEVICE_ID`
  - adds a small helper to build companion entity configs consistently
  - forwards `device_id:` to Fan Level, Swing Vertical, and Swing Horizontal selects when present
- `README.md`
  - documents the `device_id:` behavior for sub-device users

## Design

- The fix targets the root cause in code generation: helper entities were registered without the climate's `device_id:`.
- Existing configurations without `device_id:` keep their current behavior.
- The solution is intentionally narrow and does not rename entities or change unrelated Home Assistant presentation details.

## Changes

- Centralized companion entity config creation in `build_entity_config(...)`.
- Copied `device_id:` only when the parent climate config includes it.
- Added a short README note so the feature is discoverable.

## Verification

- Ran `python -m py_compile esphome/components/panaac/climate.py`
- Ran `git diff --check`

PR by Codex
