### PR TITLE
feat: add POWERFUL and ECO preset support

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,44 @@
+## Summary
+
+Fixes #14.
+
+Adds optional POWERFUL and ECO preset support to the Panasonic AC climate component. The feature is exposed through ESPHome climate presets and a companion preset select entity, with protocol encode/decode support for the relevant Panasonic IR bits.
+
+## Scope
+
+- `esphome/components/panaac/climate.py`
+  - adds `supports_powerful:` and `supports_eco:` schema options
+  - registers a companion preset select when either option is enabled
+- `esphome/components/panaac/definitions.h`
+  - defines preset strings, state storage, and Panasonic bit positions/masks
+- `esphome/components/panaac/extra.h`, `extra.cpp`
+  - adds the preset select entity implementation
+- `esphome/components/panaac/panaac.h`, `panaac.cpp`
+  - advertises supported presets in climate traits
+  - decodes POWERFUL/ECO from received IR frames
+  - encodes POWERFUL/ECO into transmitted IR frames
+  - normalizes preset behavior for unsupported modes and fan changes
+- `README.md`
+  - documents the new configuration options
+
+## Design
+
+- Presets map onto ESPHome's built-in climate preset model instead of inventing a separate control surface.
+- The feature is opt-in because not every Panasonic remote exposes POWERFUL/ECO buttons.
+- POWERFUL and ECO are cleared automatically when the climate is off or in unsupported operating modes.
+- POWERFUL is also cleared when the fan mode changes, matching the protocol behavior discussed in the issue.
+- A separate preset select keeps the feature available even in frontends that do not surface climate presets prominently.
+
+## Changes
+
+- Added preset trait advertisement for `None`, `Boost`, and `Eco` as supported.
+- Added runtime preset synchronization between climate state, helper select state, and IR receive updates.
+- Added Panasonic frame bit handling for both transmit and receive paths.
+- Updated README examples to show `supports_powerful` and `supports_eco`.
+
+## Verification
+
+- Ran `python -m py_compile esphome/components/panaac/climate.py`
+- Ran `git diff --check`
+
+PR by Codex

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a custom ESPHome external component for controlling Panasonic air condit
 It **inherits from ESPHome's `ClimateIR`** and adds support for:
 - **IR Receiver** to detect and decode Panasonic AC remote commands (216 bit frame)
 - **Temperature step** (0.5 or 1.0 degree)
+- **Preset control** for **POWERFUL** and **ECO** on supported remotes
 - **Fan Level Control** (1–5, plus quiet)
     - Default 3 levels without quiet, can configure 5 levels and quiet separately
 - **Swing Control**:
@@ -25,6 +26,7 @@ It **inherits from ESPHome's `ClimateIR`** and adds support for:
 - ✅ IR receiver support to sync state from physical remote
 - ✅ `select` components for:
   - Fan level 
+  - Preset
   - Swing vertical
   - Swing horizontal
 - ✅ Auto state updates when IR signal is received
@@ -95,6 +97,8 @@ You have 2 options to install ESPHome module to you AC.
                 supports_fan_only: true
                 supports_heat: true
                 supports_quiet: true
+                supports_powerful: true
+                supports_eco: true
                 fan_5level: true
                 swing_horizontal: false
                 temp_step: 0.5
@@ -124,11 +128,15 @@ You have 2 options to install ESPHome module to you AC.
                 supports_fan_only: true
                 supports_heat: true
                 supports_quiet: True
+                supports_powerful: True
+                supports_eco: True
                 fan_5level: True
                 swing_horizontal: True
                 temp_step: 0.5
                 ir_control: True
         ```
+
+    - `supports_powerful` and `supports_eco` are optional. When enabled, the component exposes a companion preset select and maps it to ESPHome climate presets.
 
     - **NOTE:**
         - Panasonic AC IR protocol includes 2 IR frames

--- a/esphome/components/panaac/climate.py
+++ b/esphome/components/panaac/climate.py
@@ -24,28 +24,35 @@ PanaACClimate = panaac_ns.class_('PanaACClimate', climate_ir.ClimateIR)
 PanaACFanLevel = panaac_ns.class_('PanaACFanLevel', select.Select, cg.Component)
 PanaACSwingV = panaac_ns.class_('PanaACSwingV', select.Select, cg.Component)
 PanaACSwingH = panaac_ns.class_('PanaACSwingH', select.Select, cg.Component)
+PanaACPreset = panaac_ns.class_('PanaACPreset', select.Select, cg.Component)
 
 CONF_SUPPORT_FAN_ONLY = "supports_fan_only"
 CONF_SWING_HORIZONTAL = "swing_horizontal"
 CONF_TEMP_STEP = "temp_step"
 CONF_SUPPORT_QUIET = "supports_quiet"
 CONF_FAN_5LEVEL = "fan_5level"
+CONF_SUPPORTS_POWERFUL = "supports_powerful"
+CONF_SUPPORTS_ECO = "supports_eco"
 CONF_IR_CONTROL = "ir_control"
 
 CONF_SWINGV_ID = "swingv_id"
 CONF_SWINGH_ID = "swingh_id"
 CONF_FANLEVEL_ID = "fanlevel_id"
+CONF_PRESET_ID = "preset_id"
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(PanaACClimate).extend({
     cv.GenerateID(): cv.declare_id(PanaACClimate),
     cv.GenerateID(CONF_SWINGV_ID): cv.declare_id(PanaACSwingV),
     cv.GenerateID(CONF_SWINGH_ID): cv.declare_id(PanaACSwingH),
     cv.GenerateID(CONF_FANLEVEL_ID): cv.declare_id(PanaACFanLevel),
+    cv.GenerateID(CONF_PRESET_ID): cv.declare_id(PanaACPreset),
     cv.Optional(CONF_SWING_HORIZONTAL, default=False): cv.boolean,
     cv.Optional(CONF_TEMP_STEP, default=1.0): cv.float_,
     cv.Optional(CONF_SUPPORT_QUIET, default=False): cv.boolean,
     cv.Optional(CONF_SUPPORT_FAN_ONLY, default=False): cv.boolean,
     cv.Optional(CONF_FAN_5LEVEL, default=False): cv.boolean,
+    cv.Optional(CONF_SUPPORTS_POWERFUL, default=False): cv.boolean,
+    cv.Optional(CONF_SUPPORTS_ECO, default=False): cv.boolean,
     cv.Optional(CONF_IR_CONTROL, default=False): cv.boolean,
 })
 
@@ -58,6 +65,8 @@ async def to_code(config):
     cg.add(var.set_supports_fan_only(config[CONF_SUPPORT_FAN_ONLY]))
     cg.add(var.set_supports_quiet(config[CONF_SUPPORT_QUIET]))
     cg.add(var.set_fan_5level(config[CONF_FAN_5LEVEL]))
+    cg.add(var.set_supports_powerful(config[CONF_SUPPORTS_POWERFUL]))
+    cg.add(var.set_supports_eco(config[CONF_SUPPORTS_ECO]))
     cg.add(var.set_ir_control(config[CONF_IR_CONTROL]))
 
     # Fan level select
@@ -90,3 +99,15 @@ async def to_code(config):
         await cg.register_component(swingh, swingh_default_config)
         cg.add(swingh.set_parent_climate(var))
         cg.add(var.set_swingh(swingh))
+
+    if config[CONF_SUPPORTS_POWERFUL] or config[CONF_SUPPORTS_ECO]:
+        preset_default_config = {
+            CONF_ID: config[CONF_PRESET_ID],
+            CONF_NAME: "- Preset",
+            CONF_DISABLED_BY_DEFAULT: False,
+        }
+        preset = cg.new_Pvariable(config[CONF_PRESET_ID])
+        await select.register_select(preset, preset_default_config, options=[])
+        await cg.register_component(preset, preset_default_config)
+        cg.add(preset.set_parent_climate(var))
+        cg.add(var.set_preset_select(preset))

--- a/esphome/components/panaac/definitions.h
+++ b/esphome/components/panaac/definitions.h
@@ -52,11 +52,15 @@ namespace esphome
         const uint8_t PANAAC_BYTEPOS_SWINGV = 8;
         const uint8_t PANAAC_BYTEPOS_SWINGH = 9;
         const uint8_t PANAAC_BYTEPOS_QUIET = 13;
+        const uint8_t PANAAC_BYTEPOS_POWERFUL = 13;
+        const uint8_t PANAAC_BYTEPOS_ECO = 17;
         
         // byte values
         const uint8_t PANAAC_POWER_MASK = 0x01;  // only bit 0 encodes power state
         const uint8_t PANAAC_POWER_OFF = 0x00;   // bit 0 = 0 → OFF
         const uint8_t PANAAC_POWER_ON  = 0x01;   // bit 0 = 1 → ON
+        const uint8_t PANAAC_POWERFUL_MASK = 0x01;
+        const uint8_t PANAAC_ECO_MASK = 0x10;
 
         const uint8_t PANAAC_MODE_DRY = 0x20;
         const uint8_t PANAAC_MODE_COOL = 0x30;
@@ -103,6 +107,7 @@ namespace esphome
             SwingHPos swing_h_pos;
             SwingVPos last_swing_v_pos;
             SwingHPos last_swing_h_pos;
+            climate::ClimatePreset preset{climate::CLIMATE_PRESET_NONE};
         };
 
         static const char *STR_FAN_AUTO = "Auto";
@@ -112,6 +117,9 @@ namespace esphome
         static const char *STR_FAN_L4 = "Level 4";
         static const char *STR_FAN_L5 = "Level 5";
         static const char *STR_FAN_QUIET = "Quiet";
+        static const char *STR_PRESET_NONE = "None";
+        static const char *STR_PRESET_POWERFUL = "Powerful";
+        static const char *STR_PRESET_ECO = "Eco";
 
         static const char *STR_SWINGV_AUTO = "Auto";
         static const char *STR_SWINGV_HIGHEST = "Highest";
@@ -128,6 +136,7 @@ namespace esphome
         static const char *STR_SWINGH_RIGHTMAX = "Right Max";
 
         class PanaACClimate;
+        class PanaACPreset;
 
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/extra.cpp
+++ b/esphome/components/panaac/extra.cpp
@@ -360,5 +360,51 @@ namespace esphome
         {
         }
 
+        void PanaACPreset::dump_config()
+        {
+            ESP_LOGCONFIG(TAG, "PanaACPreset:");
+            LOG_SELECT("  Preset: ", "preset", this);
+        }
+
+        void PanaACPreset::control(const std::string &value)
+        {
+            ESP_LOGI(TAG, "Preset selected: %s", value.c_str());
+
+            if (value == STR_PRESET_POWERFUL)
+            {
+                this->climate_->ac_state.preset = climate::CLIMATE_PRESET_BOOST;
+            }
+            else if (value == STR_PRESET_ECO)
+            {
+                this->climate_->ac_state.preset = climate::CLIMATE_PRESET_ECO;
+            }
+            else
+            {
+                this->climate_->ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            }
+
+            this->climate_->update_state();
+        }
+
+        void PanaACPreset::set_preset(climate::ClimatePreset preset)
+        {
+            if (preset == climate::CLIMATE_PRESET_BOOST)
+            {
+                this->publish_state(STR_PRESET_POWERFUL);
+            }
+            else if (preset == climate::CLIMATE_PRESET_ECO)
+            {
+                this->publish_state(STR_PRESET_ECO);
+            }
+            else
+            {
+                this->publish_state(STR_PRESET_NONE);
+            }
+        }
+
+        void PanaACPreset::setup()
+        {
+        }
+
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/extra.h
+++ b/esphome/components/panaac/extra.h
@@ -62,5 +62,18 @@ namespace esphome
             PanaACClimate *climate_{nullptr};
         };
 
+        class PanaACPreset : public select::Select, public Component
+        {
+        public:
+            void setup() override;
+            void dump_config() override;
+            void control(const std::string &value) override;
+            void set_parent_climate(PanaACClimate *climate) { this->climate_ = climate; }
+            void set_preset(climate::ClimatePreset preset);
+
+        protected:
+            PanaACClimate *climate_{nullptr};
+        };
+
     } // namespace panaac
 } // namespace esphome

--- a/esphome/components/panaac/panaac.cpp
+++ b/esphome/components/panaac/panaac.cpp
@@ -35,6 +35,7 @@ namespace esphome
             ac_state.swing_h_pos = PANAAC_SWINGH_AUTO;
             ac_state.last_swing_v_pos = PANAAC_SWINGV_MIDDLE;
             ac_state.last_swing_h_pos = PANAAC_SWINGH_MIDDLE;
+            ac_state.preset = climate::CLIMATE_PRESET_NONE;
 
             // fan level options
             FixedVector<const char *> fanlevel_options;
@@ -67,6 +68,22 @@ namespace esphome
             // swing v options
             this->swingv_->traits.set_options({STR_SWINGV_AUTO, STR_SWINGV_HIGHEST, STR_SWINGV_HIGH, STR_SWINGV_MIDDLE, STR_SWINGV_LOW, STR_SWINGV_LOWEST});
 
+            if (this->preset_ != nullptr)
+            {
+                FixedVector<const char *> preset_options;
+                preset_options.init(3);
+                preset_options.push_back(STR_PRESET_NONE);
+                if (this->supports_powerful_)
+                {
+                    preset_options.push_back(STR_PRESET_POWERFUL);
+                }
+                if (this->supports_eco_)
+                {
+                    preset_options.push_back(STR_PRESET_ECO);
+                }
+                this->preset_->traits.set_options(preset_options);
+            }
+
             if (this->swing_horizontal_)
             {
                 this->swingh_->traits.set_options({STR_SWINGH_AUTO, STR_SWINGH_LEFTMAX, STR_SWINGH_LEFT, STR_SWINGH_MIDDLE, STR_SWINGH_RIGHT, STR_SWINGH_RIGHTMAX});
@@ -87,6 +104,39 @@ namespace esphome
 
             transmit_state();
 
+        }
+
+        void PanaACClimate::normalize_preset_(climate::ClimateFanMode previous_fan_mode)
+        {
+            if (!this->supports_powerful_ && ac_state.preset == climate::CLIMATE_PRESET_BOOST)
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            }
+
+            if (!this->supports_eco_ && ac_state.preset == climate::CLIMATE_PRESET_ECO)
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            }
+
+            if (ac_state.mode == climate::CLIMATE_MODE_OFF ||
+                ac_state.mode == climate::CLIMATE_MODE_HEAT ||
+                ac_state.mode == climate::CLIMATE_MODE_FAN_ONLY)
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            }
+
+            if (ac_state.preset == climate::CLIMATE_PRESET_BOOST && previous_fan_mode != ac_state.fan_mode)
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            }
+        }
+
+        void PanaACClimate::sync_preset_select_()
+        {
+            if (this->preset_ != nullptr)
+            {
+                this->preset_->set_preset(ac_state.preset);
+            }
         }
 
         climate::ClimateTraits PanaACClimate::traits() {
@@ -130,6 +180,19 @@ namespace esphome
             {
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
+            }
+
+            if (this->supports_powerful_ || this->supports_eco_)
+            {
+                traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+            }
+            if (this->supports_powerful_)
+            {
+                traits.add_supported_preset(climate::CLIMATE_PRESET_BOOST);
+            }
+            if (this->supports_eco_)
+            {
+                traits.add_supported_preset(climate::CLIMATE_PRESET_ECO);
             }
             
             return traits;
@@ -309,6 +372,16 @@ namespace esphome
                     ac_state.fan_level = PANAAC_FAN_QUIET;
                 }
             }
+
+            ac_state.preset = climate::CLIMATE_PRESET_NONE;
+            if (this->supports_powerful_ && (state_bytes[PANAAC_BYTEPOS_POWERFUL] & PANAAC_POWERFUL_MASK))
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_BOOST;
+            }
+            else if (this->supports_eco_ && (state_bytes[PANAAC_BYTEPOS_ECO] & PANAAC_ECO_MASK))
+            {
+                ac_state.preset = climate::CLIMATE_PRESET_ECO;
+            }
             
             //swing
             uint8_t swing_v = state_bytes[PANAAC_BYTEPOS_SWINGV] & 0x0F;
@@ -409,8 +482,11 @@ namespace esphome
             this->mode = ac_state.mode;
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
+            this->last_fan_mode_ = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->preset = ac_state.preset;
             this->publish_state();
+            this->sync_preset_select_();
 
             this->fanlevel_->set_fanlevel(ac_state.fan_level);
             this->swingv_->set_swingvpos(ac_state.swing_v_pos);
@@ -507,6 +583,15 @@ namespace esphome
                     if (ac_state.fan_level != PANAAC_FAN_AUTO)
                         ac_state.fan_level = PANAAC_FAN_AUTO;
                     second_frame[PANAAC_BYTEPOS_FAN] |= ac_state.fan_level;
+            }
+
+            if (this->supports_powerful_ && ac_state.preset == climate::CLIMATE_PRESET_BOOST)
+            {
+                second_frame[PANAAC_BYTEPOS_POWERFUL] |= PANAAC_POWERFUL_MASK;
+            }
+            else if (this->supports_eco_ && ac_state.preset == climate::CLIMATE_PRESET_ECO)
+            {
+                second_frame[PANAAC_BYTEPOS_ECO] |= PANAAC_ECO_MASK;
             }
 
             // swing
@@ -611,6 +696,8 @@ namespace esphome
         }
         
         void PanaACClimate::transmit_state() {
+            climate::ClimateFanMode previous_fan_mode = this->last_fan_mode_;
+
             // power & mode
             ac_state.mode = this->mode;
 
@@ -645,6 +732,9 @@ namespace esphome
                 default:
                     ac_state.fan_level = PANAAC_FAN_AUTO;
             }
+
+            ac_state.preset = this->preset.has_value() ? this->preset.value() : climate::CLIMATE_PRESET_NONE;
+            this->normalize_preset_(previous_fan_mode);
 
             // swing
             ac_state.swing_mode = this->swing_mode;
@@ -707,8 +797,11 @@ namespace esphome
             this->mode = ac_state.mode;
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
+            this->last_fan_mode_ = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->preset = ac_state.preset;
             this->publish_state();
+            this->sync_preset_select_();
 
             this->fanlevel_->set_fanlevel(ac_state.fan_level);
             this->swingv_->set_swingvpos(ac_state.swing_v_pos);
@@ -720,11 +813,16 @@ namespace esphome
 
         void PanaACClimate::update_state()
         {
+            climate::ClimateFanMode previous_fan_mode = this->fan_mode.has_value() ? this->fan_mode.value() : climate::CLIMATE_FAN_AUTO;
+
             // this->fan_mode = ac_state.fan_mode;
             this->mode = ac_state.mode;
             this->target_temperature = ac_state.temp;
             this->fan_mode = ac_state.fan_mode;
             this->swing_mode = ac_state.swing_mode;
+            this->normalize_preset_(previous_fan_mode);
+            this->preset = ac_state.preset;
+            this->last_fan_mode_ = ac_state.fan_mode;
             transmit_data();
 
             // update state of additional selects
@@ -736,6 +834,7 @@ namespace esphome
             }
 
             this->publish_state();
+            this->sync_preset_select_();
 
         }
 

--- a/esphome/components/panaac/panaac.h
+++ b/esphome/components/panaac/panaac.h
@@ -38,12 +38,16 @@ namespace esphome
                                    climate::CLIMATE_SWING_BOTH,
                                    climate::CLIMATE_SWING_VERTICAL,
                                    climate::CLIMATE_SWING_HORIZONTAL},
-                                  {})
+                                  {climate::CLIMATE_PRESET_NONE,
+                                   climate::CLIMATE_PRESET_BOOST,
+                                   climate::CLIMATE_PRESET_ECO})
                                   {}
 
             void set_swing_horizontal(bool swing_horizontal) { this->swing_horizontal_ = swing_horizontal; }
             void set_temp_step(float temp_step) { this->temp_step_ = temp_step; }
             void set_supports_quiet(bool supports_quiet) { this->supports_quiet_ = supports_quiet; }
+            void set_supports_powerful(bool supports_powerful) { this->supports_powerful_ = supports_powerful; }
+            void set_supports_eco(bool supports_eco) { this->supports_eco_ = supports_eco; }
             void set_supports_fan_only(bool supports_fan_only) { this->supports_fan_only_ = supports_fan_only; }
             void set_fan_5level(bool fan_5level) { this->fan_5level_ = fan_5level; }
             void set_ir_control(bool ir_control) { this->ir_control_ = ir_control; }
@@ -51,6 +55,7 @@ namespace esphome
             void set_fanlevel(PanaACFanLevel *fanlevel) { this->fanlevel_ = fanlevel; }
             void set_swingv(PanaACSwingV *swingv) { this->swingv_ = swingv; }
             void set_swingh(PanaACSwingH *swingh) { this->swingh_ = swingh; }
+            void set_preset_select(PanaACPreset *preset) { this->preset_ = preset; }
 
             void update_state();
             void transmit_data();
@@ -63,6 +68,8 @@ namespace esphome
             void transmit_state() override;
             bool on_receive(remote_base::RemoteReceiveData data) override;
             climate::ClimateTraits traits() override;
+            void normalize_preset_(climate::ClimateFanMode previous_fan_mode);
+            void sync_preset_select_();
 
             bool decode_data(remote_base::RemoteReceiveData data, std::vector<uint8_t>& state_bytes);
             bool decode_state(std::vector<uint8_t> state_bytes, ClimateState& state);
@@ -72,10 +79,14 @@ namespace esphome
             bool fan_5level_;
             bool ir_control_;
             bool supports_fan_only_;
+            bool supports_powerful_{false};
+            bool supports_eco_{false};
+            climate::ClimateFanMode last_fan_mode_{climate::CLIMATE_FAN_AUTO};
 
             PanaACFanLevel *fanlevel_{nullptr};
             PanaACSwingV *swingv_{nullptr};
             PanaACSwingH *swingh_{nullptr};
+            PanaACPreset *preset_{nullptr};
         };
 
 


### PR DESCRIPTION
## Summary

Fixes #14.

Adds optional POWERFUL and ECO preset support to the Panasonic AC climate component. The feature is exposed through ESPHome climate presets and a companion preset select entity, with protocol encode/decode support for the relevant Panasonic IR bits.

## Scope

- `esphome/components/panaac/climate.py`
  - adds `supports_powerful:` and `supports_eco:` schema options
  - registers a companion preset select when either option is enabled
- `esphome/components/panaac/definitions.h`
  - defines preset strings, state storage, and Panasonic bit positions/masks
- `esphome/components/panaac/extra.h`, `extra.cpp`
  - adds the preset select entity implementation
- `esphome/components/panaac/panaac.h`, `panaac.cpp`
  - advertises supported presets in climate traits
  - decodes POWERFUL/ECO from received IR frames
  - encodes POWERFUL/ECO into transmitted IR frames
  - normalizes preset behavior for unsupported modes and fan changes
- `README.md`
  - documents the new configuration options

## Design

- Presets map onto ESPHome's built-in climate preset model instead of inventing a separate control surface.
- The feature is opt-in because not every Panasonic remote exposes POWERFUL/ECO buttons.
- POWERFUL and ECO are cleared automatically when the climate is off or in unsupported operating modes.
- POWERFUL is also cleared when the fan mode changes, matching the protocol behavior discussed in the issue.
- A separate preset select keeps the feature available even in frontends that do not surface climate presets prominently.

## Changes

- Added preset trait advertisement for `None`, `Boost`, and `Eco` as supported.
- Added runtime preset synchronization between climate state, helper select state, and IR receive updates.
- Added Panasonic frame bit handling for both transmit and receive paths.
- Updated README examples to show `supports_powerful` and `supports_eco`.

## Verification

- Ran `python -m py_compile esphome/components/panaac/climate.py`
- Ran `git diff --check`

PR by Codex
